### PR TITLE
unhook the change:config listener on destroy

### DIFF
--- a/src/plugins/kibana/public/settings/sections/advanced/index.js
+++ b/src/plugins/kibana/public/settings/sections/advanced/index.js
@@ -42,8 +42,12 @@ define(function (require) {
           .value();
         }
 
+        // react to changes of the config values
+        var unhook = $rootScope.$on('change:config', readConfigVals);
+        $scope.$on('$destroy', unhook);
+
+        // initial config setup
         readConfigVals();
-        $rootScope.$on('change:config', readConfigVals);
       }
     };
   });


### PR DESCRIPTION
While testing elastic/kibana#4924, I discovered that there was an event listener that was never being removed in the advanced config editor.

This fixes the issue.
